### PR TITLE
Add discardableResult to accept() method

### DIFF
--- a/Mockit/Classes/CallHandler.swift
+++ b/Mockit/Classes/CallHandler.swift
@@ -40,6 +40,7 @@ public protocol CallHandler {
 
   func getArgs(callOrder order: Int)
 
+  @discardableResult
   func accept(_ returnValue: Any?, ofFunction function: String, atFile file: String,
                      inLine line: UInt, withArgs args: Any?...) -> Any?
 

--- a/Mockit/Classes/CallHandlerImpl.swift
+++ b/Mockit/Classes/CallHandlerImpl.swift
@@ -76,6 +76,7 @@ open class CallHandlerImpl: CallHandler {
     transtion(toState: .getArgs)
   }
 
+  @discardableResult
   open func accept(_ returnValue: Any?, ofFunction function: String, atFile file: String,
                      inLine line: UInt, withArgs args: Any?...) -> Any? {
     switch state {


### PR DESCRIPTION
To suppress warnings in Swift 3, @discardableResult is added to CallHandler.accept method