### PR TITLE
Add details to argument mismatch error

### DIFF
--- a/Mockit/Classes/Stub.swift
+++ b/Mockit/Classes/Stub.swift
@@ -48,7 +48,9 @@ open class Stub {
     self.argumentMatchers = argumentMatchers
 
     guard assertArgumentMatcherCount() else {
-      fatalError("There is a mismatch between number of expected arguments and its corresponding matcher")
+      fatalError("There is a mismatch between the number of expected arguments (\(expectedArgs.count))"
+        + " and its corresponding matcher (\(argumentMatchers.count))"
+        + " in function '\(functionName ?? "?")'")
     }
 
     let actionable = Actionable(ofStub: self, withReturnValue: returnValue)


### PR DESCRIPTION
We experienced a strange error that caused some of our tests to crash, but only in our CI system, never locally. It was really hard to identify the issue, since the error message was not informative enough.
This commit is supposed to give more detail about the actual stub when this argument mismatch error occurs.